### PR TITLE
changed ITEM_DAMAGE_BONUS -> melee_damage_bonus

### DIFF
--- a/enchantments.json
+++ b/enchantments.json
@@ -3,9 +3,9 @@
     "type": "enchantment",
     "id": "DRUNKEN_UNARMED",
     "condition": { "not": "u_has_weapon" },
-    "values": [
+    "melee_damage_bonus": [
       {
-        "value": "ITEM_DAMAGE_BASH",
+        "type": "bash",
         "add": { "math": [ "rng(u_effect_intensity('drunk') * 1.8, u_effect_intensity('drunk') * 4 )" ] }
       }
     ]
@@ -14,9 +14,9 @@
     "type": "enchantment",
     "id": "DRUNKEN_ARMED",
     "condition": "u_has_weapon",
-    "values": [
+    "melee_damage_bonus": [
       {
-        "value": "ITEM_DAMAGE_BASH",
+        "type": "bash",
         "add": { "math": [ "rng(u_effect_intensity('drunk') * 1.2, u_effect_intensity('drunk') * 2.6 )" ] }
       }
     ]
@@ -25,6 +25,11 @@
     "type": "enchantment",
     "id": "KI_STRIKE",
     "condition": { "not": "u_has_weapon" },
-    "values": [ { "value": "ITEM_DAMAGE_BASH", "add": { "math": [ "u_skill('unarmed') * 2" ] } } ]
+    "melee_damage_bonus": [
+      {
+        "type": "bash",
+        "add": { "math": [ "u_skill('unarmed') * 2" ] }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Description
Changed instances of `ITEM_DAMAGE_BONUS` to use `melee_damage_bonus`.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Loaded a world with MMA and it worked.

## Notes
Related PR: https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1141