### PR TITLE
Removed Refs to `MACES`

### DIFF
--- a/martialarts.json
+++ b/martialarts.json
@@ -42,7 +42,7 @@
       "mma_tec_desert_wind_spin",
       "mma_tec_desert_wind_wide"
     ],
-    "weapon_category": [ "MACES", "EXEMPLAR_WEAPON_DESERT_WIND", "SPEARS" ]
+    "weapon_category": [ "EXEMPLAR_WEAPON_DESERT_WIND", "SPEARS" ]
   },
   {
     "type": "martial_art",
@@ -536,7 +536,7 @@
       }
     ],
     "techniques": [ "mma_tec_stone_dragon_hammer", "mma_tec_stone_dragon_strike", "mma_tec_stone_dragon_colossus" ],
-    "weapon_category": [ "MACES", "GREAT_SWORDS", "GREAT_AXES", "EXEMPLAR_WEAPON_STONE_DRAGON" ]
+    "weapon_category": [ "GREAT_SWORDS", "GREAT_AXES", "EXEMPLAR_WEAPON_STONE_DRAGON" ]
   },
   {
     "type": "martial_art",


### PR DESCRIPTION
## Description
Removed all references to the obsolete `MACES` category from the 'Desert Wind' and 'Stone Dragon' martial arts.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
<img width="627" height="144" alt="image" src="https://github.com/user-attachments/assets/9033e280-9882-415a-8cc9-0b2f4e6c0410" />
<img width="625" height="125" alt="image" src="https://github.com/user-attachments/assets/5a42df95-12e6-4a63-98f2-8518b605af3e" />

## Notes
Closes #2